### PR TITLE
skip precheck for index that already exists

### DIFF
--- a/check.go
+++ b/check.go
@@ -63,8 +63,18 @@ func (c *esclient) preCheck(ctx context.Context, conf config) error {
 	createIndices := make(map[string]struct{}, 0)
 
 	for _, ix := range conf.Indices {
+		ok, err := c.existIndex(ctx, ix.Name)
+		if err != nil {
+			return fmt.Errorf("pre-check: check index %v exists: %w", ix.Name, err)
+		}
+		if ok {
+			createIndices[ix.Name] = struct{}{}
+			c.logf("[skip] index %v already exists\n", ix.Name)
+			continue
+		}
+
 		createIndices[ix.Name] = struct{}{}
-		err := c.preCheckIndex(ctx, ix)
+		err = c.preCheckIndex(ctx, ix)
 		if err != nil {
 			c.logf("[fail] index: %v\n", ix.Name)
 			return err


### PR DESCRIPTION
close #12 

to skip precheck stage of indices that already exists.

```diff
go run ./cmd/eskeeper/main.go -v < testdata/es.yaml

loading config ...

=== validation stage ===
[pass] index: test-v1
[pass] index: test-v2
[pass] index: close-v1
[pass] alias: alias1
[pass] alias: alias2

=== pre-check stage ===
- [pass] index: test-v1
- [pass] index: test-v2
- [pass] index: close-v1
+ [skip] index test-v1 already exists
+ [skip] index test-v2 already exists
+ [skip] index close-v1  already exists
[pass] alias: alias1
[pass] alias: alias2

=== sync stage ===
[synced] index: test-v1
[synced] index: test-v2
[synced] index: close-v1
[synced] alias: alias1
[synced] alias: alias2

=== post-check stage ===
[pass] index: test-v1
[pass] index: test-v2
[pass] index: close-v1
[pass] alias: alias1
[pass] alias: alias2
```